### PR TITLE
Set enconding for setup.py file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf8 -*-
 
 from distutils.core import setup
 

--- a/spixy/irc/definitions.py
+++ b/spixy/irc/definitions.py
@@ -1,3 +1,5 @@
+# -*- coding: utf8 -*-
+
 import spixy.utils.format_parse as format_parse
 
 _host = "{{host:[0-9a-zA-Z\.\-:]+}}"


### PR DESCRIPTION
Currently the umlaut character in 'Hägg' will cause the following error:

```
$ python setup.py build
  File "setup.py", line 8
  SyntaxError: Non-ASCII character '\xc3' in file setup.py on line 8,
  but no encoding declared; see http://python.org/dev/peps/pep-0263/ for
  details
```

Correct this by setting a proper encoding according to PEP-263.
